### PR TITLE
Don't include docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["shell", "scripts", "os", "command", "runner"]
 categories = ["command-line-interface", "command-line-utilities"]
 include = [
   "/benches/*",
-  "/docs/*",
   "/examples/*",
   "/src/*",
   "/tests/*",


### PR DESCRIPTION
`docs` should not be shipped in the crate, they are available in docs.rs anyway