### PR TITLE
feat: add encoding conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ include = [
 
 [dependencies]
 fsio = { version = "^0.4", features = ["temp-path"] }
+encoding_rs = { version = "0.8.35", default-features = false, features = [
+  "alloc",
+], optional = true }
 
 [dev-dependencies]
 doc-comment = "^0.3"

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -254,8 +254,25 @@ pub(crate) fn run(
             match process_result {
                 Ok(output) => {
                     let exit_code = get_exit_code(output.status);
-                    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-                    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+                    #[cfg(feature = "encoding_rs")]
+                    let (stdout, stderr) = if let Some(encoding) = options.encoding {
+                        (
+                            encoding.decode(&output.stdout).0.into_owned(),
+                            encoding.decode(&output.stderr).0.into_owned(),
+                        )
+                    } else {
+                        (
+                            String::from_utf8_lossy(&output.stdout).into_owned(),
+                            String::from_utf8_lossy(&output.stderr).into_owned(),
+                        )
+                    };
+
+                    #[cfg(not(feature = "encoding_rs"))]
+                    let (stdout, stderr) = (
+                        String::from_utf8_lossy(&output.stdout).into_owned(),
+                        String::from_utf8_lossy(&output.stderr).into_owned(),
+                    );
 
                     Ok((exit_code, stdout, stderr))
                 }

--- a/src/runner_test.rs
+++ b/src/runner_test.rs
@@ -144,6 +144,28 @@ fn run_test_no_args_default_options() {
     assert!(error.is_empty());
 }
 
+#[cfg(feature = "encoding_rs")]
+#[test]
+fn run_test_no_args_with_encoding() {
+    let args = vec![];
+    let mut options = ScriptOptions::new();
+    options.encoding = Some(encoding_rs::UTF_8);
+
+    let (code, output, error) = run(
+        r#"
+        echo "Test"
+        exit 0
+        "#,
+        &args,
+        &options,
+    )
+    .unwrap();
+
+    assert_eq!(code, 0);
+    assert!(!output.is_empty());
+    assert!(error.is_empty());
+}
+
 #[test]
 fn run_test_error_exit_code() {
     let args = vec![];

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,8 @@
 #[path = "./types_test.rs"]
 mod types_test;
 
+#[cfg(feature = "encoding_rs")]
+use encoding_rs::Encoding;
 use fsio::error::FsIOError;
 use std::error::Error;
 use std::fmt;
@@ -68,6 +70,9 @@ pub struct ScriptOptions {
     pub print_commands: bool,
     /// Environment environment variables to add before invocation
     pub env_vars: Option<std::collections::HashMap<String, String>>,
+    /// Encoding conversion for stdout and stderr
+    #[cfg(feature = "encoding_rs")]
+    pub encoding: Option<&'static Encoding>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -93,6 +98,8 @@ impl ScriptOptions {
             exit_on_error: false,
             print_commands: false,
             env_vars: None,
+            #[cfg(feature = "encoding_rs")]
+            encoding: None,
         }
     }
 }

--- a/src/types_test.rs
+++ b/src/types_test.rs
@@ -24,4 +24,6 @@ fn script_options_new() {
     assert_eq!(options.output_redirection, IoOptions::Pipe);
     assert!(!options.exit_on_error);
     assert!(!options.print_commands);
+    #[cfg(feature = "encoding_rs")]
+    assert!(options.encoding.is_none());
 }


### PR DESCRIPTION
Sometimes stdout/stderr encoding is not UTF-8, so adding encoding conversion functionality is useful.